### PR TITLE
TestCase: Relative date

### DIFF
--- a/carbon_test.go
+++ b/carbon_test.go
@@ -1657,7 +1657,7 @@ func TestTomorrowEET(t *testing.T) {
 	tomorrow, _ := Tomorrow("Africa/Cairo")
 
 	assert.Equal(t, "Africa/Cairo", tomorrow.TimeZone())
-	assert.Equal(t, today.Day()+1, tomorrow.Day())
+	assert.Equal(t, today.AddDay().Day(), tomorrow.Day())
 }
 
 func TestTomorrowUnknown(t *testing.T) {


### PR DESCRIPTION
Fixed test :TestTomorrowEET

If we do ```today.Day()+1``` on last day of month, for eg: 31 Aug, than it will be 32 and test case will fail.
Just made it relative.