### PR TITLE
Changes in "DiffIn..." functions and also testcase fix

### DIFF
--- a/carbon.go
+++ b/carbon.go
@@ -1057,7 +1057,7 @@ func (c *Carbon) DiffInYears(carb *Carbon, abs bool) int64 {
 		return absValue(abs, diff)
 	}
 
-	return absValue(abs, 0)
+	return 0
 }
 
 // DiffInMonths returns the difference in months
@@ -1075,11 +1075,11 @@ func (c *Carbon) DiffInMonths(carb *Carbon, abs bool) int64 {
 		return absValue(abs, diff)
 	}
 
-	return absValue(abs, 0)
+	return 0
 }
 
-// DiffInString return the difference between duration in string format
-func (c *Carbon) DiffInString(carb *Carbon) string {
+// DiffDurationInString returns the duration difference in string format
+func (c *Carbon) DiffDurationInString(carb *Carbon) string {
 	if carb == nil {
 		carb = nowIn(c.Location())
 	}

--- a/carbon.go
+++ b/carbon.go
@@ -18,6 +18,7 @@ package carbon
 import (
 	"errors"
 	"math"
+	"strings"
 	"time"
 )
 
@@ -32,6 +33,8 @@ const (
 	yearsPerCenturies = 100
 	yearsPerDecade    = 10
 	weeksPerLongYear  = 53
+	daysInLeapYear    = 366
+	daysInNormalYear  = 365
 )
 
 // Represents the different string formats for dates
@@ -265,9 +268,18 @@ func (c *Carbon) Age() int {
 	return int(c.DiffInYears(Now(), true))
 }
 
-// DaysInMonth returns the number of days of the current month
+// DaysInMonth returns the number of days in the month
 func (c *Carbon) DaysInMonth() int {
 	return c.EndOfMonth().Day()
+}
+
+// DaysInYear returns the number of days in the year
+func (c *Carbon) DaysInYear() int {
+	if c.IsLeapYear() {
+		return daysInLeapYear
+	}
+
+	return daysInNormalYear
 }
 
 // WeekOfMonth returns the week of the month
@@ -1035,10 +1047,17 @@ func (c *Carbon) DiffInYears(carb *Carbon, abs bool) int64 {
 	if carb == nil {
 		carb = nowIn(c.Location())
 	}
-	t1, t2 := carb.In(time.UTC), c.In(time.UTC)
-	diff := t1.Year() - t2.Year()
 
-	return absValue(abs, int64(diff))
+	diffHr := c.DiffInHours(carb, abs)
+	hrLastYear := int64(c.DaysInYear() * hoursPerDay)
+
+	if (diffHr - hrLastYear) >= 0 {
+		diff := int64(carb.In(time.UTC).Year() - c.In(time.UTC).Year())
+
+		return absValue(abs, diff)
+	}
+
+	return absValue(abs, 0)
 }
 
 // DiffInMonths returns the difference in months
@@ -1046,10 +1065,26 @@ func (c *Carbon) DiffInMonths(carb *Carbon, abs bool) int64 {
 	if carb == nil {
 		carb = nowIn(c.Location())
 	}
-	t1, t2 := carb.In(time.UTC), c.In(time.UTC)
-	diff := c.DiffInYears(carb, abs)*monthsPerYear + int64(t1.Month()-t2.Month())
 
-	return absValue(abs, diff)
+	diffHr := c.DiffInHours(carb, abs)
+	hrLastMonth := int64(c.DaysInMonth() * hoursPerDay)
+
+	if (diffHr - hrLastMonth) >= 0 {
+		diff := c.DiffInYears(carb, abs)*monthsPerYear + int64(carb.In(time.UTC).Month()-c.In(time.UTC).Month())
+
+		return absValue(abs, diff)
+	}
+
+	return absValue(abs, 0)
+}
+
+// DiffInString return the difference between duration in string format
+func (c *Carbon) DiffInString(carb *Carbon) string {
+	if carb == nil {
+		carb = nowIn(c.Location())
+	}
+
+	return strings.Replace(carb.Sub(c.Time).String(), "-", "", 1)
 }
 
 // DiffInWeeks returns the difference in weeks

--- a/carbon_test.go
+++ b/carbon_test.go
@@ -1935,7 +1935,7 @@ func TestDiffInString(t *testing.T) {
 	t1, _ := Create(2016, time.August, 10, 10, 0, 0, 0, "UTC")
 	t2, _ := Create(2016, time.August, 1, 23, 0, 0, 0, "UTC")
 
-	assert.EqualValues(t, "203h0m0s", t1.DiffInString(t2))
+	assert.EqualValues(t, "203h0m0s", t1.DiffDurationInString(t2))
 }
 
 func TestSecondsSinceMidnight(t *testing.T) {

--- a/carbon_test.go
+++ b/carbon_test.go
@@ -1671,7 +1671,7 @@ func TestYesterdayEET(t *testing.T) {
 	yesterday, _ := Yesterday("Africa/Cairo")
 
 	assert.Equal(t, "Africa/Cairo", yesterday.TimeZone())
-	assert.Equal(t, today.Day()-1, yesterday.Day())
+	assert.Equal(t, today.SubDay().Day(), yesterday.Day())
 }
 
 func TestYesterdayUnknown(t *testing.T) {
@@ -1869,25 +1869,25 @@ func TestDiffInYearsTimeZone(t *testing.T) {
 	assert.EqualValues(t, 0, t1.DiffInYears(t2, true))
 }
 
-func TestDiffInYears(t *testing.T) {
-	t1, _ := Create(2016, time.August, 18, 10, 0, 0, 0, "UTC")
-	t2, _ := Create(1016, time.July, 29, 12, 0, 0, 0, "UTC")
-
-	assert.EqualValues(t, 1000, t1.DiffInYears(t2, true))
-}
-
-func TestDiffInYearsAbs(t *testing.T) {
-	t1 := Now()
-	t2 := t1.AddYear()
+func TestDiffInYearsOneYearDifferenceNoLeapYear(t *testing.T) {
+	t1, _ := Create(2014, time.August, 10, 14, 0, 0, 0, "UTC")
+	t2, _ := Create(2015, time.August, 10, 14, 0, 0, 0, "UTC")
 
 	assert.EqualValues(t, 1, t1.DiffInYears(t2, true))
 }
 
-func TestDiffInYearsNoAbs(t *testing.T) {
-	t1 := Now()
-	t2 := t1.AddYear()
+func TestDiffInYearsOneHourLessInYear(t *testing.T) {
+	t1, _ := Create(2014, time.August, 10, 15, 0, 0, 0, "UTC")
+	t2, _ := Create(2015, time.August, 10, 14, 0, 0, 0, "UTC")
 
-	assert.EqualValues(t, -1, t2.DiffInYears(t1, false))
+	assert.EqualValues(t, 0, t1.DiffInYears(t2, true))
+}
+
+func TestDiffInYearsOneYearDifferenceForLeapYear(t *testing.T) {
+	t1, _ := Create(2015, time.August, 10, 15, 0, 0, 0, "UTC")
+	t2, _ := Create(2016, time.August, 10, 14, 0, 0, 0, "UTC")
+
+	assert.EqualValues(t, 1, t1.DiffInYears(t2, true))
 }
 
 func TestDiffInMonthsNil(t *testing.T) {
@@ -1908,6 +1908,34 @@ func TestDiffInMonths(t *testing.T) {
 	t2, _ := Create(2015, time.July, 29, 12, 0, 0, 0, "UTC")
 
 	assert.EqualValues(t, 11, t1.DiffInMonths(t2, true))
+}
+
+func TestDiffInMonthsOneDayDifference(t *testing.T) {
+	t1, _ := Create(2016, time.September, 1, 10, 0, 0, 0, "UTC")
+	t2, _ := Create(2016, time.August, 31, 10, 0, 0, 0, "UTC")
+
+	assert.EqualValues(t, 0, t1.DiffInMonths(t2, true))
+}
+
+func TestDiffInMonthsOneMonthDifference(t *testing.T) {
+	t1, _ := Create(2016, time.September, 1, 10, 0, 0, 0, "UTC")
+	t2, _ := Create(2016, time.August, 1, 10, 0, 0, 0, "UTC")
+
+	assert.EqualValues(t, 1, t1.DiffInMonths(t2, true))
+}
+
+func TestDiffInMonthsOneHourLessInMonthDifference(t *testing.T) {
+	t1, _ := Create(2016, time.August, 1, 10, 0, 0, 0, "UTC")
+	t2, _ := Create(2016, time.September, 1, 9, 0, 0, 0, "UTC")
+
+	assert.EqualValues(t, 0, t1.DiffInMonths(t2, true))
+}
+
+func TestDiffInString(t *testing.T) {
+	t1, _ := Create(2016, time.August, 10, 10, 0, 0, 0, "UTC")
+	t2, _ := Create(2016, time.August, 1, 23, 0, 0, 0, "UTC")
+
+	assert.EqualValues(t, "203h0m0s", t1.DiffInString(t2))
 }
 
 func TestSecondsSinceMidnight(t *testing.T) {
@@ -2475,6 +2503,18 @@ func TestDaysInMonth(t *testing.T) {
 	c, _ := CreateFromDate(2016, time.February, 1, "UTC")
 
 	assert.EqualValues(t, 29, c.DaysInMonth())
+}
+
+func TestDaysInYearNormal(t *testing.T) {
+	c, _ := CreateFromDate(2015, time.February, 1, "UTC")
+
+	assert.EqualValues(t, 365, c.DaysInYear())
+}
+
+func TestDaysInYearLeap(t *testing.T) {
+	c, _ := CreateFromDate(2016, time.February, 1, "UTC")
+
+	assert.EqualValues(t, 366, c.DaysInYear())
 }
 
 func TestNowInLocation(t *testing.T) {


### PR DESCRIPTION
DiffInMonth and DiffInYear were returning 1 for different month and years even if the interval was less than 1 hour.