### PR TITLE
[RFC] Change internal Time instead of creating new Carbon instance

### DIFF
--- a/carbon.go
+++ b/carbon.go
@@ -90,8 +90,8 @@ func NewCarbon(t time.Time) *Carbon {
 }
 
 // Freeze allows time to be frozen to facilitate testing
-func Freeze(time time.Time) {
-	currentFrozenTime = time
+func Freeze(value time.Time) {
+	currentFrozenTime = value
 	isTimeFrozen = true
 }
 
@@ -384,7 +384,9 @@ func (c *Carbon) String() string {
 // AddYears adds a year to the current time.
 // Positive values travel forward while negative values travel into the past
 func (c *Carbon) AddYears(y int) *Carbon {
-	return NewCarbon(c.AddDate(y, 0, 0))
+	c.Time = c.AddDate(y, 0, 0)
+
+	return c
 }
 
 // AddYear adds a year to the current time
@@ -395,7 +397,9 @@ func (c *Carbon) AddYear() *Carbon {
 // AddQuarters adds quarters to the current time.
 // Positive values travel forward while negative values travel into the past
 func (c *Carbon) AddQuarters(q int) *Carbon {
-	return NewCarbon(c.AddDate(0, monthsPerQuarter*q, 0))
+	c.Time = c.AddDate(0, monthsPerQuarter*q, 0)
+
+	return c
 }
 
 // AddQuarter adds a quarter to the current time
@@ -406,7 +410,9 @@ func (c *Carbon) AddQuarter() *Carbon {
 // AddCenturies adds centuries to the time.
 // Positive values travels forward while negative values travels into the past
 func (c *Carbon) AddCenturies(cent int) *Carbon {
-	return NewCarbon(c.AddDate(yearsPerCenturies*cent, 0, 0))
+	c.Time = c.AddDate(yearsPerCenturies*cent, 0, 0)
+
+	return c
 }
 
 // AddCentury adds a century to the current time
@@ -417,7 +423,9 @@ func (c *Carbon) AddCentury() *Carbon {
 // AddMonths adds months to the current time.
 // Positive value travels forward while negative values travels into the past
 func (c *Carbon) AddMonths(m int) *Carbon {
-	return NewCarbon(c.AddDate(0, m, 0))
+	c.Time = c.AddDate(0, m, 0)
+
+	return c
 }
 
 // AddMonth adds a month to the current time
@@ -429,7 +437,9 @@ func (c *Carbon) AddMonth() *Carbon {
 // Positive values travels forward while negative values travels into the past.
 func (c *Carbon) AddSeconds(s int) *Carbon {
 	d := time.Duration(s) * time.Second
-	return NewCarbon(c.Add(d))
+	c.Time = c.Add(d)
+
+	return c
 }
 
 // AddSecond adds a second to the time
@@ -440,7 +450,9 @@ func (c *Carbon) AddSecond() *Carbon {
 // AddDays adds a day to the current time.
 // Positive value travels forward while negative value travels into the past
 func (c *Carbon) AddDays(d int) *Carbon {
-	return NewCarbon(c.AddDate(0, 0, d))
+	c.Time = c.AddDate(0, 0, d)
+
+	return c
 }
 
 // AddDay adds a day to the current time
@@ -474,7 +486,9 @@ func (c *Carbon) AddWeekday() *Carbon {
 // AddWeeks adds a week to the current time.
 // Positive value travels forward while negative value travels into the past.
 func (c *Carbon) AddWeeks(w int) *Carbon {
-	return NewCarbon(c.AddDate(0, 0, daysPerWeek*w))
+	c.Time = c.AddDate(0, 0, daysPerWeek*w)
+
+	return c
 }
 
 // AddWeek adds a week to the current time
@@ -486,8 +500,9 @@ func (c *Carbon) AddWeek() *Carbon {
 // Positive value travels forward while negative value travels into the past
 func (c *Carbon) AddHours(h int) *Carbon {
 	d := time.Duration(h) * time.Hour
+	c.Time = c.Add(d)
 
-	return NewCarbon(c.Add(d))
+	return c
 }
 
 // AddHour adds an hour to the current time
@@ -504,12 +519,16 @@ func (c *Carbon) AddMonthsNoOverflow(m int) *Carbon {
 		return addedDate.PreviousMonthLastDay()
 	}
 
-	return addedDate
+	c.Time = addedDate.Time
+
+	return c
 }
 
 // PreviousMonthLastDay returns the last day of the previous month
 func (c *Carbon) PreviousMonthLastDay() *Carbon {
-	return NewCarbon(c.AddDate(0, 0, -c.Day()))
+	c.Time = c.AddDate(0, 0, -c.Day())
+
+	return c
 }
 
 // AddMonthNoOverflow adds a month with no overflow to the current time
@@ -521,8 +540,9 @@ func (c *Carbon) AddMonthNoOverflow() *Carbon {
 // Positive value travels forward while negative value travels into the past.
 func (c *Carbon) AddMinutes(m int) *Carbon {
 	d := time.Duration(m) * time.Minute
+	c.Time = c.Add(d)
 
-	return NewCarbon(c.Add(d))
+	return c
 }
 
 // AddMinute adds a minute to the current time
@@ -1160,15 +1180,15 @@ func (c *Carbon) DiffInYears(carb *Carbon, abs bool) int64 {
 		end = aux
 	}
 
-	yearsAmmount := int64(end.Year()-start.Year()) - 1
+	yearsAmount := int64(end.Year()-start.Year()) - 1
 
 	start.SetYear(end.Year())
 
 	if start.UnixNano() <= end.UnixNano() {
-		yearsAmmount++
+		yearsAmount++
 	}
 
-	return absValue(abs, yearsAmmount)
+	return absValue(abs, yearsAmount)
 }
 
 // DiffInMonths returns the difference in months
@@ -1311,7 +1331,7 @@ func (c *Carbon) DiffFiltered(duration time.Duration, f Filter, carb *Carbon, ab
 		if f(end) {
 			counter++
 		}
-		end = NewCarbon(end.Add(-duration))
+		end.Time = end.Add(-duration)
 	}
 	if inverse {
 		counter = -counter
@@ -1644,14 +1664,18 @@ func (c *Carbon) LastOfMonth(wd time.Weekday) *Carbon {
 	return d.StartOfDay()
 }
 
-// LastDayOfMonth returns a new carbon instance with the last day of current month
+// LastDayOfMonth resets date to the last day of current month
 func (c *Carbon) LastDayOfMonth() *Carbon {
-	return NewCarbon(time.Date(c.Year(), c.Month(), c.DaysInMonth(), 0, 0, 0, 0, time.UTC))
+	c.Time = time.Date(c.Year(), c.Month(), c.DaysInMonth(), 0, 0, 0, 0, time.UTC)
+
+	return c
 }
 
-// FirstDayOfMonth returns a new carbon instance with the first day of current month
+// FirstDayOfMonth resets date to the first day of current month
 func (c *Carbon) FirstDayOfMonth() *Carbon {
-	return NewCarbon(time.Date(c.Year(), c.Month(), 1, 0, 0, 0, 0, time.UTC))
+	c.Time = time.Date(c.Year(), c.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	return c
 }
 
 // NthOfMonth returns the given occurrence of a given day of the week in the current month

--- a/carbon_test.go
+++ b/carbon_test.go
@@ -1514,8 +1514,9 @@ func TestLteFalseLesser(t *testing.T) {
 
 func TestBetweenTrue(t *testing.T) {
 	c := Now()
-	d := c.SubMonth()
-	b := c.AddMonth()
+
+	d := Now().SubMonth()
+	b := Now().AddMonth()
 
 	assert.True(t, c.Between(d, b, false))
 }
@@ -1531,16 +1532,16 @@ func TestBetweenEqualTrue(t *testing.T) {
 
 func TestBetweenSwapedTrue(t *testing.T) {
 	c := Now()
-	a := c.SubMonth()
-	b := c.AddMonth()
+	a := Now().SubMonth()
+	b := Now().AddMonth()
 
 	assert.True(t, c.Between(b, a, false))
 }
 
 func TestBetweenFalse(t *testing.T) {
 	c := Now()
-	d := c.SubMonth()
-	b := c.AddMonth()
+	d := Now().SubMonth()
+	b := Now().AddMonth()
 	c = c.SubMonth()
 
 	assert.False(t, c.Between(d, b, false))
@@ -1548,48 +1549,48 @@ func TestBetweenFalse(t *testing.T) {
 
 func TestClosestFirstArgument(t *testing.T) {
 	c := Now()
-	a := c.AddHour()
-	b := c.AddMonth()
+	a := Now().AddHour()
+	b := Now().AddMonth()
 
 	assert.Equal(t, a, c.Closest(a, b))
 }
 
 func TestClosestLastArgument(t *testing.T) {
 	c := Now()
-	a := c.AddHour()
-	b := c.AddSecond()
+	a := Now().AddHour()
+	b := Now().AddSecond()
 
 	assert.Equal(t, b, c.Closest(a, b))
 }
 
 func TestClosestBeforeAndAfterDates(t *testing.T) {
 	c := Now()
-	a := c.SubHour()
-	b := c.AddMinute()
+	a := Now().SubHour()
+	b := Now().AddMinute()
 
 	assert.Equal(t, b, c.Closest(a, b))
 }
 
 func TestFarthestFirstArgument(t *testing.T) {
 	c := Now()
-	a := c.AddYear()
-	b := c.AddMonth()
+	a := Now().AddYear()
+	b := Now().AddMonth()
 
 	assert.Equal(t, a, c.Farthest(a, b))
 }
 
 func TestFarthestLastArgument(t *testing.T) {
 	c := Now()
-	a := c.AddSecond()
-	b := c.AddMinute()
+	a := Now().AddSecond()
+	b := Now().AddMinute()
 
 	assert.Equal(t, b, c.Farthest(a, b))
 }
 
 func TestFarthestBeforeAndAfterDates(t *testing.T) {
 	c := Now()
-	a := c.SubHour()
-	b := c.AddMinute()
+	a := Now().SubHour()
+	b := Now().AddMinute()
 
 	assert.Equal(t, a, c.Farthest(a, b))
 }
@@ -1720,14 +1721,14 @@ func TestDiffInSecondsTimeZoneDifferentTime(t *testing.T) {
 
 func TestDiffInSecondsAbs(t *testing.T) {
 	t1 := Now()
-	t2 := t1.AddSecond()
+	t2 := Now().AddSecond()
 
 	assert.Equal(t, int64(1), t1.DiffInSeconds(t2, true))
 }
 
 func TestDiffInSecondsNoAbs(t *testing.T) {
 	t1 := Now()
-	t2 := t1.AddSecond()
+	t2 := Now().AddSecond()
 
 	assert.Equal(t, int64(-1), t2.DiffInSeconds(t1, false))
 }
@@ -1748,14 +1749,14 @@ func TestDiffInMinutesTimeZone2(t *testing.T) {
 
 func TestDiffInMinutesAbs(t *testing.T) {
 	t1 := Now()
-	t2 := t1.AddMinute()
+	t2 := Now().AddMinute()
 
 	assert.Equal(t, int64(1), t1.DiffInMinutes(t2, true))
 }
 
 func TestDiffInMinutesNoAbs(t *testing.T) {
 	t1 := Now()
-	t2 := t1.AddMinute()
+	t2 := Now().AddMinute()
 
 	assert.Equal(t, int64(-1), t2.DiffInMinutes(t1, false))
 }
@@ -1776,14 +1777,14 @@ func TestDiffInHoursTimeZone2(t *testing.T) {
 
 func TestDiffInHoursAbs(t *testing.T) {
 	t1 := Now()
-	t2 := t1.AddHour()
+	t2 := Now().AddHour()
 
 	assert.Equal(t, int64(1), t1.DiffInHours(t2, true))
 }
 
 func TestDiffInHoursNoAbs(t *testing.T) {
 	t1 := Now()
-	t2 := t1.AddHour()
+	t2 := Now().AddHour()
 
 	assert.Equal(t, int64(-1), t2.DiffInHours(t1, false))
 }
@@ -1804,14 +1805,14 @@ func TestDiffInDaysTimeZone2(t *testing.T) {
 
 func TestDiffInDaysAbs(t *testing.T) {
 	t1 := Now()
-	t2 := t1.AddDay()
+	t2 := Now().AddDay()
 
 	assert.Equal(t, int64(1), t1.DiffInDays(t2, true))
 }
 
 func TestDiffInDaysNoAbs(t *testing.T) {
 	t1 := Now()
-	t2 := t1.AddDay()
+	t2 := Now().AddDay()
 
 	assert.Equal(t, int64(-1), t2.DiffInDays(t1, false))
 }
@@ -1838,14 +1839,14 @@ func TestDiffInNightsTimeZone2(t *testing.T) {
 
 func TestDiffInNightsAbs(t *testing.T) {
 	t1 := Now()
-	t2 := t1.AddDay()
+	t2 := Now().AddDay()
 
 	assert.Equal(t, int64(1), t1.DiffInNights(t2, true))
 }
 
 func TestDiffInNightsNoAbs(t *testing.T) {
 	t1 := Now()
-	t2 := t1.AddDay()
+	t2 := Now().AddDay()
 
 	assert.Equal(t, int64(-1), t2.DiffInNights(t1, false))
 }
@@ -1878,14 +1879,14 @@ func TestDiffInWeeksTimeZone2(t *testing.T) {
 
 func TestDiffInWeeksAbs(t *testing.T) {
 	t1 := Now()
-	t2 := t1.AddWeek()
+	t2 := Now().AddWeek()
 
 	assert.Equal(t, int64(1), t1.DiffInWeeks(t2, true))
 }
 
 func TestDiffInWeeksNoAbs(t *testing.T) {
 	t1 := Now()
-	t2 := t1.AddWeek()
+	t2 := Now().AddWeek()
 
 	assert.Equal(t, int64(-1), t2.DiffInWeeks(t1, false))
 }
@@ -2606,12 +2607,11 @@ func TestCreateFromTimestampInvalidLocation(t *testing.T) {
 func TestLastDayOfMonth(t *testing.T) {
 	c, err := Create(2016, time.August, 20, 10, 0, 0, 0, "UTC")
 	assert.Nil(t, err)
-	d := c.LastDayOfMonth()
-	assert.Equal(t, 31, d.Day())
+	c.LastDayOfMonth()
+	assert.Equal(t, 31, c.Day())
 
-	c = c.AddMonth()
-	d = c.LastDayOfMonth()
-	assert.Equal(t, 30, d.Day())
+	c = c.AddDay().LastDayOfMonth()
+	assert.Equal(t, 30, c.Day())
 }
 
 func TestFirstDayOfMonth(t *testing.T) {

--- a/carboninterval.go
+++ b/carboninterval.go
@@ -7,7 +7,7 @@ import (
 // CarbonInterval represents an interval between two carbons.
 type CarbonInterval struct {
 	Start *Carbon
-	End *Carbon
+	End   *Carbon
 }
 
 // NewCarbonInterval returns a pointer to a new CarbonInterval instance
@@ -18,7 +18,7 @@ func NewCarbonInterval(start, end *Carbon) (*CarbonInterval, error) {
 
 	return &CarbonInterval{
 		Start: start,
-		End: end,
+		End:   end,
 	}, nil
 }
 

--- a/carboninterval_test.go
+++ b/carboninterval_test.go
@@ -1,9 +1,9 @@
 package carbon
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestErrorOnConstruction(t *testing.T) {


### PR DESCRIPTION
Current version is creating a new carbon instance every time it needs to use Go's Time library for calculations.
This PR makes it so the internal Time is changed in those instances.