### PR TITLE
[RFC] Add diffInMonths fix for NonUTC zones

### DIFF
--- a/carbon.go
+++ b/carbon.go
@@ -1187,11 +1187,17 @@ func (c *Carbon) DiffInMonths(carb *Carbon, abs bool) int64 {
 		carb = nowIn(c.Location())
 	}
 
-	if c.Location() != carb.Location() {
-		c = NewCarbon(c.In(time.UTC))
-		carb = NewCarbon(carb.In(time.UTC))
+	cAux := c.Copy()
+	carbAux := carb.Copy()
+	if cAux.Location() != carbAux.Location() {
+		cAux = NewCarbon(cAux.In(time.UTC))
+		carbAux = NewCarbon(carbAux.In(time.UTC))
 	}
 
+	return calculateDiffInMonths(cAux, carbAux, abs)
+}
+
+func calculateDiffInMonths(c, carb *Carbon, abs bool) int64 {
 	if c.Month() == carb.Month() && c.Year() == carb.Year() {
 		return 0
 	}

--- a/carbon.go
+++ b/carbon.go
@@ -1187,12 +1187,17 @@ func (c *Carbon) DiffInMonths(carb *Carbon, abs bool) int64 {
 		carb = nowIn(c.Location())
 	}
 
+	if c.Location() != carb.Location() {
+		c = NewCarbon(c.In(time.UTC))
+		carb = NewCarbon(carb.In(time.UTC))
+	}
+
 	if c.Month() == carb.Month() && c.Year() == carb.Year() {
 		return 0
 	}
 
 	if c.Month() != carb.Month() && c.Year() == carb.Year() {
-		diffInMonths := int64(carb.In(time.UTC).Month() - c.In(time.UTC).Month())
+		diffInMonths := int64(carb.Month() - c.Month())
 		remainingTime := int(carb.DiffInHours(c, true))
 
 		if remainingTime < c.DaysInMonth()*hoursPerDay {
@@ -1202,13 +1207,13 @@ func (c *Carbon) DiffInMonths(carb *Carbon, abs bool) int64 {
 		return absValue(abs, diffInMonths)
 	}
 
-	m := monthsPerYear - c.In(time.UTC).Month() + carb.In(time.UTC).Month() - 1
+	m := monthsPerYear - c.Month() + carb.Month() - 1
 	if c.Year() < carb.Year() && c.hasRemainingHours(carb) {
 		m = m + 1
 	}
 
 	if c.Year() > carb.Year() {
-		m = monthsPerYear - carb.In(time.UTC).Month() + c.In(time.UTC).Month() - 1
+		m = monthsPerYear - carb.Month() + c.Month() - 1
 
 		if carb.hasRemainingHours(c) {
 			m = m + 1

--- a/carbon_test.go
+++ b/carbon_test.go
@@ -2063,6 +2063,13 @@ func TestDiffInMonthsEnsureIsTruncated(t *testing.T) {
 	assert.EqualValues(t, 1, t1.DiffInMonths(t2, true))
 }
 
+func TestDiffInMonthsOverYearNonUTC(t *testing.T) {
+	t1, _ := Create(2018, time.December, 2, 0, 0, 0, 0, "EET")
+	t2, _ := Create(2019, time.February, 1, 0, 0, 0, 0, "EET")
+	assert.EqualValues(t, 1, t1.DiffInMonths(t2, false))
+}
+
+
 func TestDiffInString(t *testing.T) {
 	t1, _ := Create(2016, time.August, 10, 10, 0, 0, 0, "UTC")
 	t2, _ := Create(2016, time.August, 1, 23, 0, 0, 0, "UTC")

--- a/carbon_test.go
+++ b/carbon_test.go
@@ -2070,13 +2070,6 @@ func TestDiffInMonthsEnsureIsTruncated(t *testing.T) {
 	assert.EqualValues(t, 1, t1.DiffInMonths(t2, true))
 }
 
-func TestDiffInMonthsOverYearNonUTC(t *testing.T) {
-	t1, _ := Create(2018, time.December, 2, 0, 0, 0, 0, "EET")
-	t2, _ := Create(2019, time.February, 1, 0, 0, 0, 0, "EET")
-	assert.EqualValues(t, 1, t1.DiffInMonths(t2, false))
-}
-
-
 func TestDiffInString(t *testing.T) {
 	t1, _ := Create(2016, time.August, 10, 10, 0, 0, 0, "UTC")
 	t2, _ := Create(2016, time.August, 1, 23, 0, 0, 0, "UTC")


### PR DESCRIPTION
The issue reported in #47 and #46 is related to doing the calculation in a different timezone. Changed to do the calculations in the same TZ