### PR TITLE
Remove unused variable secondsInMonth

### DIFF
--- a/carbon.go
+++ b/carbon.go
@@ -36,7 +36,6 @@ const (
 	daysInLeapYear    = 366
 	daysInNormalYear  = 365
 	secondsInWeek     = 691200
-	secondsInMonth    = 2678400
 )
 
 // Represents the different string formats for dates


### PR DESCRIPTION
Hi! Seems variable `secondsInMonth` is unused. Please check it