### PR TITLE
[RFC]Fix end of the week when the date provider is the end of the week

### DIFF
--- a/carbon.go
+++ b/carbon.go
@@ -1602,6 +1602,10 @@ func (c *Carbon) StartOfWeek() *Carbon {
 
 // EndOfWeek returns the date of the last day of the week at 23:59:59
 func (c *Carbon) EndOfWeek() *Carbon {
+	if c.Weekday() == c.WeekEndsAt() {
+		return c.EndOfDay();
+	}
+
 	return c.Next(c.WeekEndsAt()).EndOfDay()
 }
 

--- a/carbon_test.go
+++ b/carbon_test.go
@@ -2309,6 +2309,13 @@ func TestEndOfWeek(t *testing.T) {
 
 	expected, _ := Create(2016, time.August, 28, 23, 59, 59, 999999999, "UTC")
 	assert.Equal(t, expected, t2)
+
+	// test end of week when date is last day of weekend
+	t3, _ := Create(2021, time.January, 17, 13, 0, 0, 0, "UTC")
+	t4 := t3.EndOfWeek()
+
+	expected2, _ := Create(2021, time.January, 17, 23, 59, 59, 999999999, "UTC")
+	assert.Equal(t, expected2, t4)
 }
 
 func TestNextWeekday(t *testing.T) {


### PR DESCRIPTION
When the date provided is the end of the week we should return that same date, with the end of the week format. 

This should fix this 👉  https://github.com/uniplaces/carbon/issues/61