### PR TITLE
Add fallback when loading lang file

### DIFF
--- a/lang/loader.go
+++ b/lang/loader.go
@@ -2,12 +2,24 @@ package lang
 
 import (
 	"errors"
+	"go/build"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 )
 
 // LoadLocaleText will load the translations from the locale json files according to the locale
 func LoadLocaleText(l string) ([]byte, error) {
 	lText, err := ioutil.ReadFile("./lang/" + l + ".json")
+	if os.IsNotExist(err) {
+		gopath := os.Getenv("GOPATH")
+		if gopath == "" {
+			gopath = build.Default.GOPATH
+		}
+		lPath := filepath.Join(gopath, "src", "github.com", "uniplaces", "carbon", "lang", l + ".json")
+		lText, err = ioutil.ReadFile(lPath)
+	}
+
 	if err != nil {
 		return nil, errors.New("not able to read the lang file:" + err.Error())
 	}

--- a/translator_test.go
+++ b/translator_test.go
@@ -1,6 +1,7 @@
 package carbon
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -17,4 +18,11 @@ func TestTrans(t *testing.T) {
 	c, _ := Create(2009, time.November, 10, 23, 0, 0, 0, "UTC")
 	c.SetLocale("pt")
 	assert.Equal(t, "pt", c.GetLocale())
+}
+
+func TestLoadNonExistentResource(t *testing.T) {
+	tr := NewTranslator()
+	err := tr.loadResource("iv")
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "github.com"))
 }


### PR DESCRIPTION
## Description
The lang files in the lang folder existed in the package, but when retrieved, it will search for the lang folder in the working directory (which is good, especially if you wanted to do some customization for the translations).  
This pull-request is intended to add a fallback logic for retrieving the lang file.  

## Motivation and Context
This is a possible action item for https://github.com/uniplaces/carbon/issues/58 and https://github.com/uniplaces/carbon/issues/54.
Although, you could just copy the lang folder or any lang file you desire to solve the issue.

## How Has This Been Tested?
I've added a unit-test to cover the case, but can only cater for negative test-case.
Instead, I've tested at my local by pushing the changes into my forked repo, then testing with another go file with syntax:
```
prevTime := time.Now().AddDate(0, 0, -3)
registeredAt := carbon.NewCarbon(prevTime)
currentTime := carbon.NewCarbon(time.Now())

difference, err := registeredAt.DiffForHumans(currentTime, false, false, false)
if err != nil {
log.Println(err.Error())
}

log.Println(difference)
```

## Approach
If the working directory does not have the lang file, it will check the downloaded/installed directory of the package from GoPath, then using the lang file from there.