### PR TITLE
added null checks to NewCarbonInterval

### DIFF
--- a/carboninterval.go
+++ b/carboninterval.go
@@ -7,18 +7,25 @@ import (
 // CarbonInterval represents an interval between two carbons.
 type CarbonInterval struct {
 	Start *Carbon
-	End *Carbon
+	End   *Carbon
 }
 
 // NewCarbonInterval returns a pointer to a new CarbonInterval instance
 func NewCarbonInterval(start, end *Carbon) (*CarbonInterval, error) {
+	if start == nil {
+		return nil, errors.New("start cannot be nil")
+	}
+	if end == nil {
+		return nil, errors.New("end cannot be nil")
+	}
+
 	if start.Gte(end) {
-		return nil, errors.New("The end date must be greater than the start date.")
+		return nil, errors.New("the end date must be greater than or equal to the start date")
 	}
 
 	return &CarbonInterval{
 		Start: start,
-		End: end,
+		End:   end,
 	}, nil
 }
 

--- a/carboninterval.go
+++ b/carboninterval.go
@@ -13,10 +13,10 @@ type CarbonInterval struct {
 // NewCarbonInterval returns a pointer to a new CarbonInterval instance
 func NewCarbonInterval(start, end *Carbon) (*CarbonInterval, error) {
 	if start == nil {
-		return nil, errors.New("start cannot be nil")
+		return nil, errors.New("start date cannot be nil")
 	}
 	if end == nil {
-		return nil, errors.New("end cannot be nil")
+		return nil, errors.New("end date cannot be nil")
 	}
 
 	if start.Gte(end) {

--- a/carboninterval_test.go
+++ b/carboninterval_test.go
@@ -3,6 +3,7 @@ package carbon
 import (
 	"testing"
 	"time"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,7 +12,7 @@ func TestErrorOnConstruction(t *testing.T) {
 	endDate, _ := Create(2009, time.November, 9, 23, 0, 0, 0, "UTC")
 
 	_, err := NewCarbonInterval(startDate, endDate)
-	assert.Error(t, err, "The end date must be greater than the start date.")
+	assert.Error(t, err, "the end date must be greater than or equal to the start date")
 }
 
 func TestDiffInHours(t *testing.T) {
@@ -20,4 +21,23 @@ func TestDiffInHours(t *testing.T) {
 
 	interval, _ := NewCarbonInterval(startDate, endDate)
 	assert.Equal(t, int64(1), interval.DiffInHours())
+}
+
+func TestErrorOnNilStartDate(t *testing.T) {
+	endDate, _ := Create(2009, time.November, 10, 24, 0, 0, 0, "UTC")
+
+	_, err := NewCarbonInterval(nil, endDate)
+	assert.Error(t, err, "start date cannot be nil")
+}
+
+func TestErrorOnNilEndDate(t *testing.T) {
+	startDate, _ := Create(2009, time.November, 10, 23, 0, 0, 0, "UTC")
+
+	_, err := NewCarbonInterval(startDate, nil)
+	assert.Error(t, err, "end date cannot be nil")
+}
+
+func TestErrorOnNilDates(t *testing.T) {
+	_, err := NewCarbonInterval(nil, nil)
+	assert.Error(t, err, "start date cannot be nil")
 }


### PR DESCRIPTION
```go
package main

import "github.com/uniplaces/carbon"

func main() {
	carbon.NewCarbonInterval(nil, nil)
}
```

This simple code would panic because there are no null checks in ``NewCarbonInterval``.

https://github.com/uniplaces/carbon/blob/1c77b657f1c27f275c6a835cf0ddb77764fa6577/carboninterval.go#L16

According to [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#error-strings)

> Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context.