### PR TITLE
[RFC] Fix language, use go:embed

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13, 1.14, 1.15]
+        go-version: [1.16, 1.17, 1.18]
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Carbon
 ======
-[![Build Status](https://travis-ci.org/uniplaces/carbon.svg?branch=master)](https://travis-ci.org/uniplaces/carbon)
+[![.github/workflows/pull_request.yml](https://github.com/uniplaces/carbon/actions/workflows/pull_request.yml/badge.svg)](https://github.com/uniplaces/carbon/actions/workflows/pull_request.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/uniplaces/carbon)](https://goreportcard.com/report/github.com/uniplaces/carbon)
 [![codecov](https://codecov.io/gh/uniplaces/carbon/branch/master/graph/badge.svg)](https://codecov.io/gh/uniplaces/carbon)
 [![GoDoc](https://godoc.org/github.com/uniplaces/carbon?status.svg)](https://godoc.org/github.com/uniplaces/carbon)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Carbon
 ======
-[![.github/workflows/pull_request.yml](https://github.com/uniplaces/carbon/actions/workflows/pull_request.yml/badge.svg)](https://github.com/uniplaces/carbon/actions/workflows/pull_request.yml)
+[![Build Status](https://github.com/uniplaces/carbon/actions/workflows/pull_request.yml/badge.svg)](https://github.com/uniplaces/carbon/actions/workflows/pull_request.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/uniplaces/carbon)](https://goreportcard.com/report/github.com/uniplaces/carbon)
 [![codecov](https://codecov.io/gh/uniplaces/carbon/branch/master/graph/badge.svg)](https://codecov.io/gh/uniplaces/carbon)
 [![GoDoc](https://godoc.org/github.com/uniplaces/carbon?status.svg)](https://godoc.org/github.com/uniplaces/carbon)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uniplaces/carbon
 
-go 1.15
+go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect

--- a/lang/loader.go
+++ b/lang/loader.go
@@ -1,24 +1,16 @@
 package lang
 
 import (
+	"embed"
 	"errors"
-	"go/build"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 )
+
+//go:embed *.json
+var f embed.FS
 
 // LoadLocaleText will load the translations from the locale json files according to the locale
 func LoadLocaleText(l string) ([]byte, error) {
-	lText, err := ioutil.ReadFile("./lang/" + l + ".json")
-	if os.IsNotExist(err) {
-		gopath := os.Getenv("GOPATH")
-		if gopath == "" {
-			gopath = build.Default.GOPATH
-		}
-		lPath := filepath.Join(gopath, "src", "github.com", "uniplaces", "carbon", "lang", l + ".json")
-		lText, err = ioutil.ReadFile(lPath)
-	}
+	lText, err := f.ReadFile(l + ".json")
 
 	if err != nil {
 		return nil, errors.New("not able to read the lang file:" + err.Error())

--- a/translator.go
+++ b/translator.go
@@ -61,12 +61,12 @@ func (t *Translator) AssertValidLocale(l string) error {
 
 // loadResource loads the translations according to the locale
 func (t *Translator) loadResource(l string) error {
-	ltext, err := lang.LoadLocaleText(l)
+	lText, err := lang.LoadLocaleText(l)
 	if err != nil {
 		return err
 	}
 
-	err = json.Unmarshal(ltext, &t.resources)
+	err = json.Unmarshal(lText, &t.resources)
 	if err != nil {
 		return errors.New("unable to unmarshall locale data : " + err.Error())
 	}

--- a/translator_test.go
+++ b/translator_test.go
@@ -24,5 +24,5 @@ func TestLoadNonExistentResource(t *testing.T) {
 	tr := NewTranslator()
 	err := tr.loadResource("iv")
 	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "github.com"))
+	assert.True(t, strings.Contains(err.Error(), "open iv.json: file does not exist"))
 }


### PR DESCRIPTION
Use go:embed https://pkg.go.dev/embed to not need to declare GOPATH and have language support.

This way we can have access to the languages. However, It requires that we use go version above 1.16. 