### PR TITLE
Add Carbon Period functionality

### DIFF
--- a/carbonPeriod.go
+++ b/carbonPeriod.go
@@ -1,0 +1,29 @@
+package carbon
+
+import "errors"
+
+// Period returns an array of Carbon dates by accepting start date, number of
+// days, and end date. Useful for generating a recurring dates.
+func Period(start *Carbon, days int, end *Carbon) ([]*Carbon, error) {
+	if end.Before(start.Time) {
+		return nil, errors.New("end date must be after start date")
+	}
+	if days <= 0 {
+		return nil, errors.New("days must be at least 1")
+	}
+
+	want := make([]*Carbon, 0)
+
+	want = append(want, start)
+
+	next := start
+	for {
+		try := next.AddDays(days)
+		if try.Before(end.Time) {
+			want = append(want, try)
+			next = try
+		} else {
+			return want, nil
+		}
+	}
+}

--- a/carbonPeriod.go
+++ b/carbonPeriod.go
@@ -2,14 +2,19 @@ package carbon
 
 import "errors"
 
+var (
+	ErrEndMustBeAfterStart = errors.New("end date must be after start date")
+	ErrDayAtLeast1         = errors.New("days must be at least 1")
+)
+
 // Period returns an array of Carbon dates by accepting start date, number of
 // days, and end date. Useful for generating a recurring dates.
 func Period(start *Carbon, days int, end *Carbon) ([]*Carbon, error) {
 	if end.Before(start.Time) {
-		return nil, errors.New("end date must be after start date")
+		return nil, ErrEndMustBeAfterStart
 	}
 	if days <= 0 {
-		return nil, errors.New("days must be at least 1")
+		return nil, ErrDayAtLeast1
 	}
 
 	want := make([]*Carbon, 0)
@@ -19,11 +24,12 @@ func Period(start *Carbon, days int, end *Carbon) ([]*Carbon, error) {
 	next := start
 	for {
 		try := next.AddDays(days)
-		if try.Before(end.Time) {
-			want = append(want, try)
-			next = try
-		} else {
+
+		if try.Gte(end) {
 			return want, nil
 		}
+
+		want = append(want, try)
+		next = try
 	}
 }

--- a/carbonPeriod_test.go
+++ b/carbonPeriod_test.go
@@ -13,17 +13,17 @@ func TestNewPeriod(t *testing.T) {
 
 	days := 7
 
-	want := make([]*Carbon, 0)
+	wantTime := make([]*Carbon, 0)
 	want1a, _ := Create(2022, time.April, 1, 23, 0, 0, 0, "UTC")
 	want1b, _ := Create(2022, time.April, 8, 23, 0, 0, 0, "UTC")
 	want1c, _ := Create(2022, time.April, 15, 23, 0, 0, 0, "UTC")
 	want1d, _ := Create(2022, time.April, 22, 23, 0, 0, 0, "UTC")
 	want1e, _ := Create(2022, time.April, 29, 23, 0, 0, 0, "UTC")
-	want = append(want, want1a)
-	want = append(want, want1b)
-	want = append(want, want1c)
-	want = append(want, want1d)
-	want = append(want, want1e)
+	wantTime = append(wantTime, want1a)
+	wantTime = append(wantTime, want1b)
+	wantTime = append(wantTime, want1c)
+	wantTime = append(wantTime, want1d)
+	wantTime = append(wantTime, want1e)
 
 	type args struct {
 		start *Carbon
@@ -31,28 +31,61 @@ func TestNewPeriod(t *testing.T) {
 		end   *Carbon
 	}
 
+	type want struct {
+		wantTime []*Carbon
+		error
+	}
+
 	tests := []struct {
 		name string
 		args args
-		want []*Carbon
+		//want []*Carbon
+		want
 	}{
 		{
-			name: "days",
+			name: "normal",
 			args: args{
 				start: start1,
 				days:  days,
 				end:   end1,
 			},
-			want: want,
+			want: want{
+				wantTime: wantTime,
+				error:    nil,
+			},
+		},
+		{
+			name: "date to is before date start",
+			args: args{
+				start: end1,
+				days:  1,
+				end:   start1,
+			},
+			want: want{
+				wantTime: nil,
+				error:    ErrEndMustBeAfterStart,
+			},
+		},
+		{
+			name: "day is zero",
+			args: args{
+				start: start1,
+				days:  0,
+				end:   end1,
+			},
+			want: want{
+				wantTime: nil,
+				error:    ErrDayAtLeast1,
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := Period(tt.args.start, tt.args.days, tt.args.end)
-			assert.NoError(t, err)
+			assert.Equal(t, tt.want.error, err)
 
 			for key, val := range got {
-				assert.Equal(t, tt.want[key], val)
+				assert.Equal(t, tt.want.wantTime[key], val)
 			}
 		})
 	}

--- a/carbonPeriod_test.go
+++ b/carbonPeriod_test.go
@@ -1,0 +1,59 @@
+package carbon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPeriod(t *testing.T) {
+	start1, _ := Create(2022, time.April, 1, 23, 0, 0, 0, "UTC")
+	end1, _ := Create(2022, time.April, 30, 23, 0, 0, 0, "UTC")
+
+	days := 7
+
+	want := make([]*Carbon, 0)
+	want1a, _ := Create(2022, time.April, 1, 23, 0, 0, 0, "UTC")
+	want1b, _ := Create(2022, time.April, 8, 23, 0, 0, 0, "UTC")
+	want1c, _ := Create(2022, time.April, 15, 23, 0, 0, 0, "UTC")
+	want1d, _ := Create(2022, time.April, 22, 23, 0, 0, 0, "UTC")
+	want1e, _ := Create(2022, time.April, 29, 23, 0, 0, 0, "UTC")
+	want = append(want, want1a)
+	want = append(want, want1b)
+	want = append(want, want1c)
+	want = append(want, want1d)
+	want = append(want, want1e)
+
+	type args struct {
+		start *Carbon
+		days  int
+		end   *Carbon
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want []*Carbon
+	}{
+		{
+			name: "days",
+			args: args{
+				start: start1,
+				days:  days,
+				end:   end1,
+			},
+			want: want,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Period(tt.args.start, tt.args.days, tt.args.end)
+			assert.NoError(t, err)
+
+			for key, val := range got {
+				assert.Equal(t, tt.want[key], val)
+			}
+		})
+	}
+}

--- a/examples/period.go
+++ b/examples/period.go
@@ -1,0 +1,22 @@
+package examples
+
+import (
+	"fmt"
+
+	"github.com/uniplaces/carbon"
+)
+
+func period() {
+	t1, _ := carbon.Create(2012, 1, 1, 12, 0, 0, 0, "Lisbon/Rome")
+	t2, _ := carbon.Create(2012, 1, 31, 12, 0, 0, 0, "Lisbon/Rome")
+	days := 7
+
+	periods, err := carbon.Period(t1, days, t2)
+	if err != nil {
+		return
+	}
+
+	for _, val := range periods {
+		fmt.Println(val)
+	}
+}


### PR DESCRIPTION
Adds a simple Carbon Period functionality https://carbon.nesbot.com/docs/#api-period that only accepts 
1. Start date
2. period in days
3. End date

It returns an array of `Carbon`.